### PR TITLE
added function query_execution_by_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This plugin only support viewing Athena result. Doesn't support post query to At
 Grafana doesn't support cache the result now, post query when dashboard is open will cause too much AWS cost.
 So, please post query outside of this plugin.
 
+If you have hundreds or thousands of executed queries in Athena, some functions of this plugin may run a very long time, because it needs iterate all executed queries. You should use workgroups in Athena and keep relevant queries for Grafana separate. 
+
+
 ### Setup
 Follow [Installing Plugins Manually](https://grafana.com/docs/plugins/installation/) steps, and install plugin from released zip file.
 
@@ -26,10 +29,28 @@ Name | Description
 *named_query_names(region)* | Returns a list of named query names.
 *named_query_queries(region, pattern)* | Returns a list of named query expressions which name match `pattern`.
 *query_execution_ids(region, limit, pattern, work_group?)* | Returns a list of query execution ids which query match `pattern`. If a `work_group` is specified, only execution_ids within that work_group will be returned.
+*query_execution_by_name(region, limit, pattern, work_group?)* | Returns most recent query execution_id which query name matches `pattern`. If a `work_group` is specified, only execution_ids within that work_group will be returned.
 
 The `query_execution_ids()` result is always sorted by `CompletionDateTime` in descending order.
 
+### Formats
+
+#### Time Format
+
+The time format field needs to follow the pattern that GO time parsing uses. 
+E.g.: "2006-01-02T15:04:05.999999-07:00"
+Examples here:https://gobyexample.com/time-formatting-parsing
+
+#### Legend Format
+
+
+
+
+
 #### Changelog
+
+##### v1.1.6
+- Added function query_execution_by_name to get most recent query executiion based on a query saved with a specific name
 
 ##### v1.1.0
 - Added support for [athena work groups](https://docs.aws.amazon.com/athena/latest/ug/user-created-workgroups.html) to work around the long api call for execution ids

--- a/datasource.go
+++ b/datasource.go
@@ -458,7 +458,17 @@ func (t *AwsAthenaDatasource) metricFindQuery(ctx context.Context, tsdbReq *data
 		pattern := parameters.Get("pattern").MustString()
 		log.Print("Pattern: ",pattern)
 		r := regexp.MustCompile(pattern)
-		li := &athena.ListNamedQueriesInput{}
+		
+		var workGroupParam *string
+		workGroupParam = nil
+		if workGroup, ok := parameters.CheckGet("work_group"); ok {
+			temp := workGroup.MustString()
+			workGroupParam = &temp
+		}
+		
+		li := &athena.ListNamedQueriesInput{
+			WorkGroup: workGroupParam,
+		}
 		lo := &athena.ListNamedQueriesOutput{}
 		sql := ""
 		err = svc.ListNamedQueriesPages(li,
@@ -498,12 +508,7 @@ func (t *AwsAthenaDatasource) metricFindQuery(ctx context.Context, tsdbReq *data
 		//}
 		//to := time.Unix(toRaw/1000, toRaw%1000*1000*1000)
 
-		var workGroupParam *string
-		workGroupParam = nil
-		if workGroup, ok := parameters.CheckGet("work_group"); ok {
-			temp := workGroup.MustString()
-			workGroupParam = &temp
-		}
+
 
 		limit := parameters.Get("limit").MustInt()
 		eli := &athena.ListQueryExecutionsInput{

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -161,6 +161,27 @@ export default class AwsAthenaDatasource extends DataSourceApi<AwsAthenaQuery, A
       });
     }
 
+    const queryExecutionIdsNamedQuery = query.match(/^query_execution_by_name\(([^,]+?),\s?([^,]+?),\s?([^,]+)(,\s?.+)?\)/);
+    if (queryExecutionIdsNamedQuery) {
+      region = queryExecutionIdsNamedQuery[1];
+      const limit = queryExecutionIdsNamedQuery[2];
+      const pattern = queryExecutionIdsNamedQuery[3];
+      let workGroup = queryExecutionIdsNamedQuery[4];
+      if (workGroup) {
+        workGroup = workGroup.substr(1); //remove the comma
+        workGroup = workGroup.trim();
+      } else {
+        workGroup = null;
+      }
+
+      return this.doMetricQueryRequest('query_execution_by_name', {
+        region: this.templateSrv.replace(region),
+        limit: parseInt(this.templateSrv.replace(limit), 10),
+        pattern: this.templateSrv.replace(pattern, {}, 'regex'),
+        work_group: this.templateSrv.replace(workGroup),
+      });
+    }
+
     return this.q.when([]);
   }
 


### PR DESCRIPTION
I added a function that allows to specify a name of a saved query and it will go through all executed queries, starting most recent first and pick the first query it finds with this specific SQL string and return the execution_id.